### PR TITLE
fix ios "postMessage" window.dispatchEvent to document.dispatchEvent

### DIFF
--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -690,7 +690,7 @@ static NSDictionary* customCertificatesForHost;
 {
   NSDictionary *eventInitDict = @{@"data": message};
   NSString *source = [NSString
-    stringWithFormat:@"window.dispatchEvent(new MessageEvent('message', %@));",
+    stringWithFormat:@"(new MessageEvent('message', %@));",
     RCTJSONStringify(eventInitDict, NULL)
   ];
   [self injectJavaScript: source];


### PR DESCRIPTION
"window.dispatchEvent" can not be received event by "document.addEventListener", so I change It to "document.dispatchEvent";
Android already uses "document.dispatchEvent", so android works fine;